### PR TITLE
Global terraform repos

### DIFF
--- a/templates/terraform/.github/workflows/terraform.yml
+++ b/templates/terraform/.github/workflows/terraform.yml
@@ -57,10 +57,7 @@ jobs:
         run: |
           if [ -d "tfvars/${STAGE}/global" ]; then
             echo "Global Repo Detected"
-            echo "REGION_PATH=global" >> $GITHUB_ENV
-          else 
-            echo "Regional Repo Detected"
-            echo "REGION_PATH=${{ secrets.AWS_TEST_REGION }}" >> $GITHUB_ENV
+            echo "REGION=global" >> $GITHUB_ENV
           fi
 
       - name: Terraform Setup
@@ -75,7 +72,7 @@ jobs:
         uses: bitdefendermdr/build-harness@master
         with:
           entrypoint: /usr/bin/make
-          args: tf/init/${STAGE}/${REGION_PATH}
+          args: tf/init/${STAGE}/${REGION}
 
       - name: Terraform Linting
         id: lint
@@ -99,12 +96,34 @@ jobs:
         uses: bitdefendermdr/build-harness@master
         with:
           entrypoint: /usr/bin/make
-          args: tf/plan/${STAGE}/${REGION_PATH}
+          args: tf/plan/${STAGE}/${REGION}
+
+      - name: Terraform Show
+        id: show
+        continue-on-error: true
+        uses: bitdefendermdr/build-harness@master
+        with:
+          entrypoint: /usr/bin/make
+          args: tf/show/${STAGE}/${REGION}
+
+      - name: Show Path
+        id: showpath
+        run: |
+          if [ -d "infra" ]; then
+            echo "infra directory detected"
+            echo "FILEPATH=./infra/tf-${STAGE}-${REGION}.show" >> $GITHUB_ENV
+          else
+            echo "FILEPATH=./tf-${STAGE}-${REGION}.show" >> $GITHUB_ENV
+          fi
+
+      - name: Set output for show
+        id: showoutput
+        run: echo "::set-output name=plan::$(base64 -w0 < ${FILEPATH})"
 
       - uses: actions/github-script@v5
         if: github.event.pull_request.sender.login != 'ACT'
         env:
-          PLAN: "terraform\n${{ steps.plan.outputs.stdout }}"
+          PLAN: "${{ steps.showoutput.outputs.plan }}"
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/templates/terraform/.github/workflows/terraform.yml
+++ b/templates/terraform/.github/workflows/terraform.yml
@@ -60,7 +60,7 @@ jobs:
             echo "REGION_PATH=global" >> $GITHUB_ENV
           else 
             echo "Regional Repo Detected"
-            echo "REGION_PATH=${REGION}" >> GITHUB_ENV
+            echo "REGION_PATH=${{ secrets.AWS_TEST_REGION }}" >> $GITHUB_ENV
           fi
 
       - name: Terraform Setup

--- a/templates/terraform/.github/workflows/terraform.yml
+++ b/templates/terraform/.github/workflows/terraform.yml
@@ -108,6 +108,9 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
+            let plan_b64 = process.env.PLAN;
+            let buff = Buffer.from(plan_b64, "base64");
+            let plan = buff.toString("utf-8");
             const output = `#### Terraform Initialization ⚙️\`${{ steps.init.outcome }}\`
             #### Terraform Linting 🖌\`${{ steps.lint.outcome }}\`
             #### Terraform Security Analysis 🤖\`${{ steps.sec.outcome }}\`
@@ -116,7 +119,7 @@ jobs:
             <details><summary>Show Plan</summary>
 
             \`\`\`\n
-            ${process.env.PLAN}
+            ${plan}
             \`\`\`
 
             </details>

--- a/templates/terraform/.github/workflows/terraform.yml
+++ b/templates/terraform/.github/workflows/terraform.yml
@@ -52,6 +52,16 @@ jobs:
 
       - name: Checkout source code
         uses: actions/checkout@v2
+      
+      - name: Global Repo Check
+        run: |
+          if [ -d "tfvars/${STAGE}/global" ]; then
+            echo "Global Repo Detected"
+            echo "REGION_PATH=global" >> $GITHUB_ENV
+          else 
+            echo "Regional Repo Detected"
+            echo "REGION_PATH=${REGION}" >> GITHUB_ENV
+          fi
 
       - name: Terraform Setup
         uses: bitdefendermdr/build-harness@master
@@ -65,7 +75,7 @@ jobs:
         uses: bitdefendermdr/build-harness@master
         with:
           entrypoint: /usr/bin/make
-          args: tf/init/${STAGE}/${REGION}
+          args: tf/init/${STAGE}/${REGION_PATH}
 
       - name: Terraform Linting
         id: lint
@@ -89,7 +99,7 @@ jobs:
         uses: bitdefendermdr/build-harness@master
         with:
           entrypoint: /usr/bin/make
-          args: tf/plan/${STAGE}/${REGION}
+          args: tf/plan/${STAGE}/${REGION_PATH}
 
       - uses: actions/github-script@v5
         if: github.event.pull_request.sender.login != 'ACT'
@@ -98,9 +108,6 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            let plan_b64 = process.env.PLAN;
-            let buff = Buffer.from(plan_b64, "base64");
-            let plan = buff.toString("utf-8");
             const output = `#### Terraform Initialization ⚙️\`${{ steps.init.outcome }}\`
             #### Terraform Linting 🖌\`${{ steps.lint.outcome }}\`
             #### Terraform Security Analysis 🤖\`${{ steps.sec.outcome }}\`
@@ -109,7 +116,7 @@ jobs:
             <details><summary>Show Plan</summary>
 
             \`\`\`\n
-            ${plan}
+            ${process.env.PLAN}
             \`\`\`
 
             </details>


### PR DESCRIPTION
## what
Terraform git action cannot detect global vs regional repo. This PR fixes that limitation.

## why
This eliminates the bespoke changes needed to terraform repos with global resources.

## references
Global Test
https://github.com/BitdefenderMDR/aws-global-accelerator/runs/5430185584?check_suite_focus=true
Regional Test
https://github.com/BitdefenderMDR/lambda-http-monitor/runs/5430623835?check_suite_focus=true
