### PR TITLE
add vendor folder with gitignore

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Available targets:
   flake8/install                      Install flake8
   git/export                          Export git vars
   github/init                         Initialize GitHub directory with default .github files
+  github/vendor                       Create the vendor directory and add gitignore
   help                                Help screen
   help/all                            Display help for all targets
   help/short                          This help short screen

--- a/docs/targets.md
+++ b/docs/targets.md
@@ -23,6 +23,7 @@ Available targets:
   flake8/install                      Install flake8
   git/export                          Export git vars
   github/init                         Initialize GitHub directory with default .github files
+  github/vendor                       Create the vendor directory and add gitignore
   help                                Help screen
   help/all                            Display help for all targets
   help/short                          This help short screen

--- a/modules/github/Makefile.init
+++ b/modules/github/Makefile.init
@@ -16,6 +16,11 @@ GITHUB_TERRAFORM_TEMPLATES = \
 GITHUB_PYTHON_TEMPLATES = \
 	.github/workflows/python.yml
 
+## Create the vendor directory and add gitignore
+github/vendor:
+	mkdir -p vendor
+	echo -e "*\n!.gitignore" > vendor/.gitignore
+
 $(GITHUB_TEMPLATES): $(addprefix $(BUILD_HARNESS_PATH)/templates/, $(GITHUB_TEMPLATES))
 	mkdir -p $(dir $@)
 	cp $(BUILD_HARNESS_PATH)/templates/$@ $@
@@ -34,4 +39,4 @@ $(GITHUB_PYTHON_TEMPLATES): $(addprefix $(BUILD_HARNESS_PATH)/templates/python/,
 .PHONY: $(GITHUB_TEMPLATES) $(GITHUB_TERRAFORM_TEMPLATES) $(GITHUB_PYTHON_TEMPLATES)
 
 ## Initialize GitHub directory with default .github files
-github/init: $(GITHUB_TEMPLATES) $(if $(or $(wildcard *.tf),$(wildcard **/*.tf)),$(GITHUB_TERRAFORM_TEMPLATES)) $(if $(or $(wildcard *.py),$(wildcard **/*.py)),$(GITHUB_PYTHON_TEMPLATES))
+github/init: $(GITHUB_TEMPLATES) $(if $(or $(wildcard *.tf),$(wildcard **/*.tf)),$(GITHUB_TERRAFORM_TEMPLATES)) $(if $(or $(wildcard *.py),$(wildcard **/*.py)),$(GITHUB_PYTHON_TEMPLATES)) github/vendor


### PR DESCRIPTION
## what
* adds `github/vendor` target to create vendor folder with gitignore

## why
* vendor folder does not exist and causes errors when running `make terraform/install` or similar commands in other repos 

## references
* closes #4
