### PR TITLE
Bump Pip packages' versions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,3 +1,4 @@
+---
 name: lint
 
 on:
@@ -14,9 +15,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source code
-        uses: actions/checkout@master
+        uses: actions/checkout@main
 
       - name: README lint
+        # Cannot point to current ref (e.g. ${{ github.ref }}),
+        # See https://github.com/orgs/community/discussions/25246
         uses: bitdefendermdr/build-harness@master
         with:
           entrypoint: /usr/bin/make

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,12 +27,12 @@ RUN apk --update --no-cache add \
       py3-ruamel.yaml && \
     python3 -m pip install --upgrade pip setuptools wheel && \
     pip3 install --no-cache-dir \
-      PyYAML==5.4.1 \
-      awscli==1.20.28 \
+      cryptography==41.0.2 \
+      awscli==1.29.9 \
       boto==2.49.0 \
-      boto3==1.18.28 \
+      boto3==1.28.9 \
       iteration-utilities==0.11.0 \
-      PyGithub==1.54.1 && \
+      PyGithub==1.59 && \
     git config --global advice.detachedHead false
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]


### PR DESCRIPTION
## what
* Bump the Pip packages' versions
  * cryptography==41.0.2
  * PyYAML==6.0.1
  * awscli==1.29.9
  * boto==2.49.0
  * boto3==1.28.9
  * iteration-utilities==0.11.0
  * PyGithub==1.59

## why
* Keeping dependencies up-to-date

## references
* N/A
